### PR TITLE
Removing the previous execution state for pythonExecute function

### DIFF
--- a/src/CodeEditor.js
+++ b/src/CodeEditor.js
@@ -117,6 +117,9 @@ hello_world()`);
     }
 
     try {
+      // removing the previous execution state for pythonExecute function
+      pyodideRef.current.runPython(`globals().clear()`);
+
       await pyodideRef.current.loadPackagesFromImports(code);
       let output = '';
       pyodideRef.current.globals.set('print', (s) => {


### PR DESCRIPTION
### its look like when we Execute the python code its PythonExecute function stores the previous state so by the help of this line of code we can remove the previous state and run it without having any error..
 pyodideRef.current.runPython(`globals().clear()`); 

#12 resolved