### PR TITLE
Typo Fix: "Install dependencies::" -> "Install dependencies:"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is a code editor built with React and Monaco Editor. It allows users to wri
    cd code-editor
    ```
 
- 2. **Install dependencies:**:
+ 2. **Install dependencies**:
     ```bash
     npm install
     ```


### PR DESCRIPTION
Fixes #16 

I have removed an extra colon from the README.md
`Install dependencies::` -> `Install dependencies:`

![Colon removed](https://github.com/user-attachments/assets/00a6e28f-978f-4781-a488-defaf1a0f97f)


