### PR TITLE
feat: add GitHub issue and PR templates for Hacktoberfest

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: 🐛 Bug Report
+about: Report a bug to help us improve the Code Editor
+title: '[BUG] '
+labels: ['bug']
+assignees: ''
+---
+
+## 🐛 Bug Description
+<!-- A clear and concise description of what the bug is. -->
+
+## 🔄 Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. Type '...'
+4. See error
+
+## ✅ Expected Behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## ❌ Actual Behavior
+<!-- A clear and concise description of what actually happened. -->
+
+## 📸 Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## 🌐 Environment
+- **Browser:** [e.g. Chrome, Firefox, Safari]
+- **Version:** [e.g. 22]
+- **OS:** [e.g. Windows 10, macOS, Ubuntu]
+- **Device:** [e.g. Desktop, Mobile]
+
+## 🔍 Code Sample
+<!-- If applicable, provide a minimal code sample that reproduces the issue -->
+```javascript
+// Your code here
+```
+
+## 📋 Additional Context
+<!-- Add any other context about the problem here. -->
+
+## 🎃 Hacktoberfest
+- [ ] I would like to work on fixing this bug
+- [ ] This is my first contribution to this project
+- [ ] I need guidance on how to fix this issue

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 GitHub Discussions
+    url: https://github.com/RhythmPahwa14/Code-Editor/discussions
+    about: Ask questions and discuss ideas with the community
+  - name: 📖 Contributing Guidelines
+    url: https://github.com/RhythmPahwa14/Code-Editor/blob/main/CONTRIBUTING.md
+    about: Learn how to contribute to this project

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,43 @@
+---
+name: 📚 Documentation Improvement
+about: Suggest improvements to documentation, README, or guides
+title: '[DOCS] '
+labels: ['documentation', 'good first issue', 'hacktoberfest']
+assignees: ''
+---
+
+## 📖 Documentation Issue
+<!-- What documentation needs to be improved, added, or fixed? -->
+
+## 📍 Location
+<!-- Where is this documentation located? (file path, section, etc.) -->
+
+## 🔍 Current State
+<!-- What is currently documented (if anything)? -->
+
+## ✨ Proposed Improvement
+<!-- What should be changed, added, or removed? -->
+
+## 🎯 Target Audience
+<!-- Who would benefit from this documentation improvement? -->
+- [ ] New contributors
+- [ ] Experienced developers
+- [ ] End users
+- [ ] Project maintainers
+
+## 📋 Type of Documentation
+- [ ] README updates
+- [ ] Code comments
+- [ ] API documentation
+- [ ] Setup/installation guide
+- [ ] Contributing guidelines
+- [ ] Examples/tutorials
+- [ ] Other: ___________
+
+## 💡 Additional Context
+<!-- Any additional information that might be helpful -->
+
+## 🎃 Hacktoberfest
+- [ ] I would like to work on this documentation
+- [ ] This is suitable for first-time contributors
+- [ ] I need guidance on project documentation standards

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,50 @@
+---
+name: ✨ Feature Request
+about: Suggest a new feature or enhancement for the Code Editor
+title: '[FEATURE] '
+labels: ['enhancement', 'hacktoberfest']
+assignees: ''
+---
+
+## 🚀 Feature Description
+<!-- A clear and concise description of the feature you'd like to see implemented. -->
+
+## 💡 Motivation
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## 📝 Detailed Description
+<!-- Provide a detailed description of how this feature should work. -->
+
+## 🎨 Mockups/Examples
+<!-- If applicable, add mockups, wireframes, or examples of similar features from other applications. -->
+
+## ✅ Acceptance Criteria
+<!-- Define what needs to be done for this feature to be considered complete. -->
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## 🛠️ Implementation Ideas
+<!-- If you have ideas on how to implement this feature, please share them. -->
+
+## 📱 Device/Platform Support
+<!-- Which devices or platforms should this feature support? -->
+- [ ] Desktop
+- [ ] Mobile
+- [ ] All browsers
+- [ ] Specific browsers: ___________
+
+## 🔗 Related Issues
+<!-- Link any related issues or discussions -->
+
+## 🎯 Priority
+<!-- How important is this feature? -->
+- [ ] High - Critical for project success
+- [ ] Medium - Would significantly improve user experience
+- [ ] Low - Nice to have enhancement
+
+## 🎃 Hacktoberfest
+- [ ] I would like to implement this feature
+- [ ] This is suitable for beginners
+- [ ] This requires advanced knowledge
+- [ ] I need guidance on implementation

--- a/.github/ISSUE_TEMPLATE/hacktoberfest.md
+++ b/.github/ISSUE_TEMPLATE/hacktoberfest.md
@@ -1,0 +1,63 @@
+---
+name: 🎃 Hacktoberfest Contribution
+about: Special template for Hacktoberfest contributors
+title: '[HACKTOBERFEST] '
+labels: ['hacktoberfest', 'good first issue']
+assignees: ''
+---
+
+## 🎃 Hacktoberfest Contribution
+
+**Welcome to Hacktoberfest!** Thank you for your interest in contributing to the Code Editor project!
+
+## 🚀 What would you like to work on?
+<!-- Please select one or more areas you'd like to contribute to -->
+
+### 🐛 Bug Fixes
+- [ ] Fix existing bugs
+- [ ] Improve error handling
+- [ ] UI/UX improvements
+
+### ✨ New Features
+- [ ] Add new programming language support
+- [ ] Implement new editor features
+- [ ] Add keyboard shortcuts
+- [ ] File import/export functionality
+
+### 📚 Documentation
+- [ ] Improve README
+- [ ] Add code examples
+- [ ] Create tutorials
+- [ ] Fix typos
+
+### 🧪 Testing
+- [ ] Add unit tests
+- [ ] Add integration tests
+- [ ] Improve test coverage
+
+### 🎨 UI/UX Improvements
+- [ ] Design improvements
+- [ ] Accessibility enhancements
+- [ ] Mobile responsiveness
+- [ ] Theme customization
+
+## 💪 Your Experience Level
+- [ ] First-time contributor to open source
+- [ ] Experienced in React/JavaScript
+- [ ] Familiar with Monaco Editor
+- [ ] New to this project but experienced developer
+
+## 🛠️ Technical Details
+<!-- If you have a specific idea, please describe it here -->
+
+## 📋 Additional Information
+<!-- Any additional context, questions, or comments -->
+
+## 🤝 Mentorship
+- [ ] I would like guidance from maintainers
+- [ ] I'm confident and can work independently
+- [ ] I'd like to pair program with someone
+
+---
+
+**Note for maintainers:** Please assign appropriate labels (`good first issue`, specific technology labels, etc.) and provide guidance to help this contributor succeed! 🌟

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## 🎯 Description
+<!-- Briefly describe what this PR does -->
+
+## 📋 Type of Change
+<!-- Mark the relevant option with an "x" -->
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)  
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] 📚 Documentation update
+- [ ] 🎨 Style/UI update
+- [ ] ♻️ Code refactoring (no functional changes)
+- [ ] 🧪 Test improvements
+
+## 🔗 Related Issues
+<!-- Link any related issues using "Fixes #123" or "Closes #123" -->
+Fixes #
+
+## 🧪 Testing
+<!-- Describe how you tested your changes -->
+- [ ] I have tested this code locally
+- [ ] I have added/updated tests
+- [ ] All existing tests pass
+- [ ] I have tested on multiple browsers (if applicable)
+
+## 📸 Screenshots (if applicable)
+<!-- Add screenshots for UI changes -->
+
+## ✅ Checklist
+<!-- Mark completed items with an "x" -->
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
+
+## 🎃 Hacktoberfest (if applicable)
+- [ ] This PR is for Hacktoberfest
+- [ ] This is my first contribution to this project
+- [ ] I have followed the Hacktoberfest guidelines
+
+## 📝 Additional Notes
+<!-- Add any additional notes, concerns, or implementation details -->


### PR DESCRIPTION
- Add bug report template with environment details and reproduction steps
- Add feature request template with acceptance criteria
- Add documentation improvement template for docs contributions
- Add Hacktoberfest-specific contributor template
- Add pull request template with testing checklist
- Configure issue template settings to improve contributor experience

These templates help organize contributions and provide clear guidance for new contributors during Hacktoberfest 2024.